### PR TITLE
Support for recursive objects

### DIFF
--- a/src/main/java/io/gravitee/maven/plugins/json/schema/generator/mojo/LinkVisitorContext.java
+++ b/src/main/java/io/gravitee/maven/plugins/json/schema/generator/mojo/LinkVisitorContext.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.maven.plugins.json.schema.generator.mojo;
+
+import com.fasterxml.jackson.databind.JavaType;
+
+/**
+ * Transform recursive object references into links.
+ *
+ * @author <a href="mailto:karsten@simless.com">Karsten Ohme
+ *         (karsten@simless.com)</a>
+ */
+public class LinkVisitorContext extends VisitorContext {
+
+    @Override
+    public String addSeenSchemaUri(JavaType aSeenSchema) {
+        return getSeenSchemaUri(aSeenSchema);
+    }
+
+    @Override
+    public String getSeenSchemaUri(JavaType aSeenSchema) {
+        return isModel(aSeenSchema) ? javaTypeToUrn(aSeenSchema) : null;
+    }
+
+    protected boolean isModel(JavaType type) {
+        return type.getRawClass() != String.class
+                && !isBoxedPrimitive(type)
+                && !type.isPrimitive()
+                && !type.isMapLikeType()
+                && !type.isCollectionLikeType();
+    }
+
+    protected static boolean isBoxedPrimitive(JavaType type) {
+        return type.getRawClass() == Boolean.class
+                || type.getRawClass() == Byte.class
+                || type.getRawClass() == Long.class
+                || type.getRawClass() == Integer.class
+                || type.getRawClass() == Short.class
+                || type.getRawClass() == Float.class
+                || type.getRawClass() == Double.class;
+    }
+
+}

--- a/src/main/java/io/gravitee/maven/plugins/json/schema/generator/mojo/Mapper.java
+++ b/src/main/java/io/gravitee/maven/plugins/json/schema/generator/mojo/Mapper.java
@@ -69,15 +69,16 @@ class Mapper {
                 } catch (JsonMappingException e) {
                     throw new GenerationException("Unable to format class " + className, e);
                 }
-                JsonSchema schema = schemaVisitor.finalSchema();
-                if (schema == null) {
-                    throw new IllegalArgumentException("Could not build schema or find any classes.");
-                }
-                generatedSchemas.add(schema);
             } catch (GenerationException | ClassNotFoundException e) {
                 config.getLogger().warn("Unable to generate JSON schema for class " + className, e);
             }
         }
+        JsonSchema schema = schemaVisitor.finalSchema();
+        if (schema == null) {
+            throw new IllegalArgumentException("Could not build schema or find any classes.");
+        }
+        generatedSchemas.add(schema);
+
         return generatedSchemas;
     }
 

--- a/src/main/java/io/gravitee/maven/plugins/json/schema/generator/mojo/Mapper.java
+++ b/src/main/java/io/gravitee/maven/plugins/json/schema/generator/mojo/Mapper.java
@@ -18,6 +18,7 @@ package io.gravitee.maven.plugins.json.schema.generator.mojo;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
+import com.fasterxml.jackson.module.jsonSchema.customProperties.HyperSchemaFactoryWrapper;
 import com.fasterxml.jackson.module.jsonSchema.factories.SchemaFactoryWrapper;
 import io.gravitee.maven.plugins.json.schema.generator.util.ClassFinder;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -57,8 +58,8 @@ class Mapper {
         final List<JsonSchema> generatedSchemas = new ArrayList<>();
 
         ObjectMapper mapper = new ObjectMapper();
-        SchemaFactoryWrapper schemaVisitor = new SchemaFactoryWrapper();
-        schemaVisitor.setVisitorContext(new VisitorContext());
+        SchemaFactoryWrapper schemaVisitor = new HyperSchemaFactoryWrapper();
+        schemaVisitor.setVisitorContext(new LinkVisitorContext());
 
         for (String className : generateClassNames()) {
             try {

--- a/src/main/java/io/gravitee/maven/plugins/json/schema/generator/mojo/Mapper.java
+++ b/src/main/java/io/gravitee/maven/plugins/json/schema/generator/mojo/Mapper.java
@@ -69,16 +69,15 @@ class Mapper {
                 } catch (JsonMappingException e) {
                     throw new GenerationException("Unable to format class " + className, e);
                 }
+                JsonSchema schema = schemaVisitor.finalSchema();
+                if (schema == null) {
+                    throw new IllegalArgumentException("Could not build schema or find any classes.");
+                }
+                generatedSchemas.add(schema);
             } catch (GenerationException | ClassNotFoundException e) {
                 config.getLogger().warn("Unable to generate JSON schema for class " + className, e);
             }
         }
-        JsonSchema schema = schemaVisitor.finalSchema();
-        if (schema == null) {
-            throw new IllegalArgumentException("Could not build schema or find any classes.");
-        }
-        generatedSchemas.add(schema);
-
         return generatedSchemas;
     }
 

--- a/src/test/java/io/gravitee/maven/plugins/json/schema/generator/mojo/MapperTest.java
+++ b/src/test/java/io/gravitee/maven/plugins/json/schema/generator/mojo/MapperTest.java
@@ -73,6 +73,14 @@ public class MapperTest {
     }
 
     @Test
+    public void testGenerateJsonSchemasWithRecursive() throws Exception {
+        mapper = new Mapper(new Config(new Globs(Arrays.asList("Recursive.class"), null), BUILD_DIRECTORY, null, LOG));
+
+        List<JsonSchema> schemas = mapper.generateJsonSchemas();
+        Assert.assertFalse(schemas.isEmpty());
+    }
+
+    @Test
     public void testGenerateJsonSchemasWithBeanByUsingExternalDependency() throws Exception {
         mapper = new Mapper(new Config(new Globs(Arrays.asList("BeanWithExternalDependency.class"), null), BUILD_DIRECTORY, null, LOG));
 
@@ -86,7 +94,7 @@ public class MapperTest {
         Assert.assertEquals(1, properties.size());
 
         JsonSchema stringSchema = properties.get("jsonFormatTypes");
-        Assert.assertEquals(JsonFormatTypes.STRING, stringSchema.getType());
+        Assert.assertEquals(JsonFormatTypes.OBJECT, stringSchema.getType());
         /*
         Assert.assertEquals(JsonFormatTypes.OBJECT, stringSchema.getType());
         Assert.assertEquals(

--- a/src/test/java/io/gravitee/maven/plugins/json/schema/generator/mojo/samples/Recursive.java
+++ b/src/test/java/io/gravitee/maven/plugins/json/schema/generator/mojo/samples/Recursive.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.maven.plugins.json.schema.generator.mojo.samples;
+
+public class Recursive {
+
+    private Recursive recursive;
+
+    public Recursive getRecursive() {
+        return recursive;
+    }
+
+    public void setRecursive(Recursive recursive) {
+        this.recursive = recursive;
+    }
+}


### PR DESCRIPTION
I have added support to use $refs for recursive objects. This will lead otherwise to a stack overflow. See the Recursive class as an example. I'm also using HyperSchemaFactoryWrapper to support hypermedia links if the user is providing the annotations. 