### PR TITLE
Enum support and write only fields

### DIFF
--- a/src/main/java/io/gravitee/maven/plugins/json/schema/generator/mojo/LinkVisitorContext.java
+++ b/src/main/java/io/gravitee/maven/plugins/json/schema/generator/mojo/LinkVisitorContext.java
@@ -39,6 +39,7 @@ public class LinkVisitorContext extends VisitorContext {
         return type.getRawClass() != String.class
                 && !isBoxedPrimitive(type)
                 && !type.isPrimitive()
+                && !type.isEnumType()
                 && !type.isMapLikeType()
                 && !type.isCollectionLikeType();
     }

--- a/src/main/java/io/gravitee/maven/plugins/json/schema/generator/mojo/Mapper.java
+++ b/src/main/java/io/gravitee/maven/plugins/json/schema/generator/mojo/Mapper.java
@@ -72,7 +72,11 @@ class Mapper {
                 }
                 JsonSchema schema = schemaVisitor.finalSchema();
                 if (schema == null) {
-                    throw new IllegalArgumentException("Could not build schema or find any classes.");
+                    throw new IllegalArgumentException("Could not build schema for class '"+className+"'.");
+                }
+                if (schema.getId() == null) {
+                    config.getLogger().warn("Ignoring invalid schema for class '"+className+"'.");
+                    continue;
                 }
                 generatedSchemas.add(schema);
             } catch (GenerationException | ClassNotFoundException e) {

--- a/src/main/java/io/gravitee/maven/plugins/json/schema/generator/mojo/Output.java
+++ b/src/main/java/io/gravitee/maven/plugins/json/schema/generator/mojo/Output.java
@@ -95,7 +95,7 @@ class Output {
             config.getLogger().info("Created JSON Schema: " + outputPath.normalize().toAbsolutePath().toString());
         } catch (JsonProcessingException e) {
             config.getLogger().warn("Unable to display schema " + schema.getId(), e);
-        } catch (IOException e) {
+        } catch (Exception e) {
             config.getLogger().warn("Unable to write Json file for schema " + schema.getId(), e);
         }
     }

--- a/src/test/java/io/gravitee/maven/plugins/json/schema/generator/mojo/MapperTest.java
+++ b/src/test/java/io/gravitee/maven/plugins/json/schema/generator/mojo/MapperTest.java
@@ -26,6 +26,7 @@ import org.mockito.Mockito;
 
 import java.io.File;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -69,7 +70,7 @@ public class MapperTest {
         mapper = new Mapper(new Config(new Globs(Arrays.asList("NoBean.class"), null), BUILD_DIRECTORY, null, LOG));
 
         List<JsonSchema> schemas = mapper.generateJsonSchemas();
-        Assert.assertFalse(schemas.isEmpty());
+        Assert.assertTrue(schemas.isEmpty());
     }
 
     @Test
@@ -94,14 +95,9 @@ public class MapperTest {
         Assert.assertEquals(1, properties.size());
 
         JsonSchema stringSchema = properties.get("jsonFormatTypes");
-        Assert.assertEquals(JsonFormatTypes.OBJECT, stringSchema.getType());
-        /*
-        Assert.assertEquals(JsonFormatTypes.OBJECT, stringSchema.getType());
-        Assert.assertEquals(
-                "jsonFormatTypes",
-                stringSchema.getId().substring(stringSchema.getId().lastIndexOf(":") + 1, stringSchema.getId().length())
-        );
-        */
+        Assert.assertEquals(JsonFormatTypes.STRING, stringSchema.getType());
+        Assert.assertEquals(new HashSet<>(Arrays.asList("string", "number", "integer",
+                "boolean", "object", "array", "null", "any")), stringSchema.asValueTypeSchema().getEnums());
     }
 
 


### PR DESCRIPTION
So far enums were not supported and were incorrectly included as $refs although no schema was generated. With this patch enums are serialized as included string lists and not as reference anymore. The corresponding JUnit test was updated.

Write only fields have been omitted. This is also fixed.

In addition I have fixed:

warning with log message for all exceptions not only for I/O exceptions
warning about unhandled classes